### PR TITLE
chore(@solidjs/router): `Link` and `NavLink` deprecated

### DIFF
--- a/src/presets/solid-router.ts
+++ b/src/presets/solid-router.ts
@@ -2,8 +2,9 @@ import type { ImportsMap } from '../types'
 
 export default <ImportsMap>({
   '@solidjs/router': [
-    'Link',
-    'NavLink',
+    'Link', // Deprecated
+    'A',
+    'NavLink', // Deprecated
     'Navigate',
     'Outlet',
     'Route',


### PR DESCRIPTION
### Description

> https://github.com/solidjs/solid-router/blob/d0695a715912db2480e082d03e5f0533a8b87e2d/src/components.tsx#L246

As you can see, they still export them for now but instead of `Link`, we use `A` component now. I kept the deprecated imports but added `A` since it's the one in the documentation now.

