### PR TITLE
fix: config.root for win32

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -1,6 +1,7 @@
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { existsSync, promises as fs } from 'node:fs'
 import process from 'node:process'
+import os from 'node:os'
 import { slash, throttle, toArray } from '@antfu/utils'
 import { createFilter } from '@rollup/pluginutils'
 import { isPackageExists } from 'local-pkg'
@@ -32,8 +33,11 @@ async function scanDirExports(dirs: string[], root: string) {
   const files = Array.from(new Set(result.flat())).map(slash)
   return (await Promise.all(files.map(i => scanExports(i, false)))).flat()
 }
+const isWindows = os.platform() === 'win32';
 
 export function createContext(options: Options = {}, root = process.cwd()) {
+  root=isWindows?slash(root):root;
+
   const {
     dts: preferDTS = isPackageExists('typescript'),
   } = options


### PR DESCRIPTION

![c2440d46ed9f4b1f2fd740dfe862f10](https://github.com/unplugin/unplugin-auto-import/assets/70076074/451c1437-06c1-4873-ae1a-7a418ccbbb8f)

Invalid sorting of type file generation, resulting in unnecessary git versions
Reading DTS file is empty while writing the file is incomplete


> vite

Debugger attached.
环境变量 VITE_DROP_CONSOLE undefined
configResolved 《======= **【Trigger Event 1】**
scanDirs writeConfigFilesThrottled
writeConfigFiles
readFile Ing 1700340039378  《======= **【Trigger Event 1 readFile Ing】**
originalContent：/* eslint-disable */
/* prettier-ignore */
// @ts-nocheck
// noinspection JSUnusedGlobalSymbols
// Generated by unplugin-auto-import
export {}
declare global {
  const $: typeof import('vue/macros')['$']
  const $$: typeof import('vue/macros')['$$']
  const $computed: typeof import('vue/macros')['$c 1700340039385
content !== lastDTS writeFile true
buildStart  《======= **【Trigger Event 2】**
scanDirs writeConfigFilesThrottled
writeConfigFiles
readFile Ing 1700340039970  《======= **【Trigger Event 2 readFile Ing】**
writeFile ing :  《======= **【Trigger Event 1 writeFile Ing】**
    E:\hby\project\**\**\packages\vite-vue3-admin-main\auto-imports.d.ts
    /* eslint-disable */
/* prettier-ignore */
// @ts-nocheck
// noinspection JSUnusedGlobalSymbols
// Generated by unplugin-auto-import
export {}
declare global {
  const $: typeof import('vue/macros')['$']
  const $$: typeof import('vue/macros')['$$']
  const $computed: typeof import('vue/macros')['$c 1700340039988

  VITE v4.5.0  ready in 7238 ms

  ➜  Local:   http://localhost:8088/
  ➜  Network: http://198.18.0.1:8088/
  ➜  Network: http://192.168.110.110:8088/
  ➜  press h to show help
originalContent： 1700340040095  《======= **【Trigger Event 2 readFile End content empty】**
content !== lastDTS writeFile false
writeFile end : 1700340040098  《======= **【Trigger Event 1 writeFile End】**
writeFile ing :
    E:\hby\project\**\**\packages\vite-vue3-admin-main\auto-imports.d.ts
    /* eslint-disable */
/* prettier-ignore */
// @ts-nocheck
// noinspection JSUnusedGlobalSymbols
// Generated by unplugin-auto-import
export {}
declare global {
  const $$: typeof import('vue/macros')['$$']
  const $: typeof import('vue/macros')['$']
  const $computed: typeof import('vue/macros')['$c 1700340040104
writeFile end : 1700340040115

It was found that the configResolved event triggered writing to the file while the buildStart event triggered it

Vite related pr
https://github.com/vitejs/vite/pull/1693

![fea7d33124812fd4a4a5bcf5b2186c3](https://github.com/unplugin/unplugin-auto-import/assets/70076074/0d1dc5c4-230c-4969-b98b-54f1cdcb369b)
Can also read file locks