### PR TITLE
feat(preset): add `@mdi/js` support

### DIFF
--- a/examples/vite-svelte/package.json
+++ b/examples/vite-svelte/package.json
@@ -9,6 +9,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
+    "@mdi/js": "^7.3.67",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^4.2.5",

--- a/examples/vite-svelte/src/App.svelte
+++ b/examples/vite-svelte/src/App.svelte
@@ -25,5 +25,7 @@
   <br />
 
   <Counter />
+
+  <pre>{ mdiAbacus }</pre>
 </main>
 

--- a/examples/vite-svelte/vite.config.ts
+++ b/examples/vite-svelte/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         'svelte',
         'svelte/store',
         'svelte/transition',
+        '@mdi/js',
       ],
       dts: './src/auto-imports.d.ts',
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
 
   examples/vite-svelte:
     devDependencies:
+      '@mdi/js':
+        specifier: ^7.3.67
+        version: 7.3.67
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
         version: 3.0.0(svelte@4.2.5)(vite@5.0.0)
@@ -1382,6 +1385,10 @@ packages:
       cross-spawn: 7.0.3
       string-argv: 0.3.1
       type-detect: 4.0.8
+    dev: true
+
+  /@mdi/js@7.3.67:
+    resolution: {integrity: sha512-MnRjknFqpTC6FifhGHjZ0+QYq2bAkZFQqIj8JA2AdPZbBxUvr8QSgB2yPAJ8/ob/XkR41xlg5majDR3c1JP1hw==}
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -236,7 +236,7 @@ export async function flattenImports(map: Options['imports']): Promise<Import[]>
         if (!presets[definition])
           throw new Error(`[auto-import] preset ${definition} not found`)
         const preset = presets[definition]
-        definition = typeof preset === 'function' ? preset() : preset
+        definition = typeof preset === 'function' ? await preset() : preset
       }
 
       if ('from' in definition && 'imports' in definition) {

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -30,6 +30,7 @@ import solidAppRouter from './solid-app-router'
 import { jotai, jotaiUtils } from './jotai'
 import vueuseMath from './vueuse-math'
 import recoil from './recoil'
+import mdiJs from './mdi-js'
 
 export const presets = {
   ...builtinPresets,
@@ -63,6 +64,7 @@ export const presets = {
   'jotai': jotai,
   'jotai/utils': jotaiUtils,
   'recoil': recoil,
+  '@mdi/js': mdiJs,
 }
 
 export type PresetName = keyof typeof presets

--- a/src/presets/mdi-js.ts
+++ b/src/presets/mdi-js.ts
@@ -1,0 +1,21 @@
+import type { ImportsMap } from '../types'
+
+let _cache: ImportsMap | undefined
+
+export default async (): Promise<ImportsMap> => {
+  if (!_cache) {
+    try {
+      // @ts-expect-error maybe missing
+      const mdiNames = await import('@mdi/js').then(m => m.default || m)
+      _cache = {
+        '@mdi/js': Object.keys(mdiNames),
+      }
+    }
+    catch (error) {
+      console.error(error)
+      throw new Error('[auto-import] failed to load @mdi/js, have you installed it?')
+    }
+  }
+
+  return _cache || {}
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR includes:
- change the context to await when preset definition is an async function, we're using dynamic import to import all the icons from `@mdi/js`  module
- add usage in Svelte example

### Linked Issues

closes #446

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
