### PR TITLE
docs: update cjs usage in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ export default {
 <details>
 <summary>Webpack</summary><br>
 
-From version `v0.17.0+` you need to use `default` export:
 ```ts
 // webpack.config.js
 module.exports = {
@@ -100,40 +99,17 @@ module.exports = {
 }
 ```
 
-If you are using a version earlier than `v0.17.0`:
-```ts
-// webpack.config.js
-module.exports = {
-  /* ... */
-  plugins: [
-    require('unplugin-auto-import/webpack')({ /* options */ }),
-  ],
-}
-```
-
 <br></details>
 
 <details>
 <summary>Rspack</summary><br>
 
-From version `v0.17.0+` you need to use `default` export:
 ```ts
 // rspack.config.js
 module.exports = {
   /* ... */
   plugins: [
     require('unplugin-auto-import/rspack').default({ /* options */ }),
-  ],
-}
-```
-
-If you are using a version earlier than `v0.17.0`:
-```ts
-// rspack.config.js
-module.exports = {
-  /* ... */
-  plugins: [
-    require('unplugin-auto-import/rspack')({ /* options */ }),
   ],
 }
 ```
@@ -150,7 +126,6 @@ module.exports = {
 <details>
 <summary>Vue CLI</summary><br>
 
-From version `v0.17.0+` you need to use `default` export:
 ```ts
 // vue.config.js
 module.exports = {
@@ -161,7 +136,7 @@ module.exports = {
 }
 ```
 
-or you can rename the Vue configuration file to `vue.config.mjs` and use static import syntax (you should use latest `@vue/cli-service ^5.0.8`):
+You can also rename the Vue configuration file to `vue.config.mjs` and use static import syntax (you should use latest `@vue/cli-service ^5.0.8`):
 ```ts
 // vue.config.mjs
 import AutoImport from 'unplugin-auto-import/webpack'
@@ -170,18 +145,6 @@ export default {
   configureWebpack: {
     plugins: [
       AutoImport({ /* options */ }),
-    ],
-  },
-}
-```
-
-If you are using a version earlier than `v0.17.0`:
-```ts
-// vue.config.js
-module.exports = {
-  configureWebpack: {
-    plugins: [
-      require('unplugin-auto-import/webpack')({ /* options */ }),
     ],
   },
 }
@@ -204,26 +167,9 @@ export default defineConfig({
 })
 ```
 
-From version `v0.17.0+` you need to use `default` export:
 ```ts
 // quasar.conf.js [Webpack]
 const AutoImportPlugin = require('unplugin-auto-import/webpack').default
-
-module.exports = {
-  build: {
-    chainWebpack(chain) {
-      chain.plugin('unplugin-auto-import').use(
-        AutoImportPlugin({ /* options */ }),
-      )
-    },
-  },
-}
-```
-
-If you are using a version earlier than `v0.17.0`:
-```ts
-// quasar.conf.js [Webpack]
-const AutoImportPlugin = require('unplugin-auto-import/webpack')
 
 module.exports = {
   build: {

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ export default {
 <details>
 <summary>Webpack</summary><br>
 
+From version `v0.17.0+` you need to use `default` export:
+```ts
+// webpack.config.js
+module.exports = {
+  /* ... */
+  plugins: [
+    require('unplugin-auto-import/webpack').default({ /* options */ }),
+  ],
+}
+```
+
+If you are using a version earlier than `v0.17.0`:
 ```ts
 // webpack.config.js
 module.exports = {
@@ -104,6 +116,18 @@ module.exports = {
 <details>
 <summary>Rspack</summary><br>
 
+From version `v0.17.0+` you need to use `default` export:
+```ts
+// rspack.config.js
+module.exports = {
+  /* ... */
+  plugins: [
+    require('unplugin-auto-import/webpack').default({ /* options */ }),
+  ],
+}
+```
+
+If you are using a version earlier than `v0.17.0`:
 ```ts
 // rspack.config.js
 module.exports = {
@@ -126,6 +150,32 @@ module.exports = {
 <details>
 <summary>Vue CLI</summary><br>
 
+From version `v0.17.0+` you need to use `default` export:
+```ts
+// vue.config.js
+module.exports = {
+  /* ... */
+  plugins: [
+    require('unplugin-auto-import/webpack').default({ /* options */ }),
+  ],
+}
+```
+
+or you can rename the Vue configuration file to `vue.config.mjs` and use static import syntax (you should use latest `@vue/cli-service ^5.0.8`):
+```ts
+// vue.config.mjs
+import AutoImport from 'unplugin-auto-import/webpack'
+
+export default {
+  configureWebpack: {
+    plugins: [
+      AutoImport({ /* options */ }),
+    ],
+  },
+}
+```
+
+If you are using a version earlier than `v0.17.0`:
 ```ts
 // vue.config.js
 module.exports = {
@@ -143,14 +193,34 @@ module.exports = {
 <summary>Quasar</summary><br>
 
 ```ts
-// quasar.conf.js [Vite]
+// vite.config.js [Vite]
+import { defineConfig } from 'vite'
+import AutoImport from 'unplugin-auto-import/vite'
+
+export default defineConfig({
+  plugins: [
+    AutoImport({ /* options */ })
+  ]
+})
+```
+
+From version `v0.17.0+` you need to use `default` export:
+```ts
+// quasar.conf.js [Webpack]
+const AutoImportPlugin = require('unplugin-auto-import/webpack').default
+
 module.exports = {
-  vitePlugins: [
-    ['unplugin-auto-import/vite', { /* options */ }],
-  ],
+  build: {
+    chainWebpack(chain) {
+      chain.plugin('unplugin-auto-import').use(
+        AutoImportPlugin({ /* options */ }),
+      )
+    },
+  },
 }
 ```
 
+If you are using a version earlier than `v0.17.0`:
 ```ts
 // quasar.conf.js [Webpack]
 const AutoImportPlugin = require('unplugin-auto-import/webpack')
@@ -172,6 +242,22 @@ module.exports = {
 <details>
 <summary>esbuild</summary><br>
 
+From version `v0.17.0+` you need to use `default` export:
+```ts
+// esbuild.config.js
+import { build } from 'esbuild'
+
+build({
+  /* ... */
+  plugins: [
+    require('unplugin-auto-import/esbuild').default({
+      /* options */
+    }),
+  ],
+})
+```
+
+If you are using a version earlier than `v0.17.0`:
 ```ts
 // esbuild.config.js
 import { build } from 'esbuild'

--- a/README.md
+++ b/README.md
@@ -242,30 +242,15 @@ module.exports = {
 <details>
 <summary>esbuild</summary><br>
 
-From version `v0.17.0+` you need to use `default` export:
 ```ts
 // esbuild.config.js
 import { build } from 'esbuild'
+import AutoImport from 'unplugin-auto-import/esbuild'
 
 build({
   /* ... */
   plugins: [
-    require('unplugin-auto-import/esbuild').default({
-      /* options */
-    }),
-  ],
-})
-```
-
-If you are using a version earlier than `v0.17.0`:
-```ts
-// esbuild.config.js
-import { build } from 'esbuild'
-
-build({
-  /* ... */
-  plugins: [
-    require('unplugin-auto-import/esbuild')({
+    AutoImport({
       /* options */
     }),
   ],

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ From version `v0.17.0+` you need to use `default` export:
 module.exports = {
   /* ... */
   plugins: [
-    require('unplugin-auto-import/webpack').default({ /* options */ }),
+    require('unplugin-auto-import/rspack').default({ /* options */ }),
   ],
 }
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR includes the breaking changes introduced in `v0.17.0` about CJS default exports:
- webpack
- rspack (no idea if will resolve default export `export.__esModule=true`, I need to do a test)
- esbuild (no idea if will resolve default export `export.__esModule=true`, I need to do a test)
- Vue CLI
- quasar: updated also Vite usage


### Linked Issues

closes #452

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
