### PR TITLE
feat: add support for BiomeJS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,13 @@ AutoImport({
     filepath: './.eslintrc-auto-import.json', // Default `./.eslintrc-auto-import.json`
     globalsPropValue: true, // Default `true`, (true | false | 'readonly' | 'readable' | 'writable' | 'writeable')
   },
+
+  // Generate corresponding .eslintrc-auto-import.json file.
+  // eslint globals Docs - https://eslint.org/docs/user-guide/configuring/language-options#specifying-globals
+  biomelintrc: {
+    enabled: false, // Default `false`
+    filepath: './.biomelintrc-auto-import.json', // Default `./.eslintrc-auto-import.json`
+  },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -316,11 +316,11 @@ AutoImport({
     globalsPropValue: true, // Default `true`, (true | false | 'readonly' | 'readable' | 'writable' | 'writeable')
   },
 
-  // Generate corresponding .eslintrc-auto-import.json file.
-  // eslint globals Docs - https://eslint.org/docs/user-guide/configuring/language-options#specifying-globals
+  // Generate corresponding .biomelintrc-auto-import.json file.
+  // biomejs extends Docs - https://biomejs.dev/guides/how-biome-works/#the-extends-option
   biomelintrc: {
     enabled: false, // Default `false`
-    filepath: './.biomelintrc-auto-import.json', // Default `./.eslintrc-auto-import.json`
+    filepath: './.biomelintrc-auto-import.json', // Default `./.biomelintrc-auto-import.json`
   },
 })
 ```

--- a/src/core/biomelintrc.ts
+++ b/src/core/biomelintrc.ts
@@ -3,8 +3,8 @@ import type { Import } from 'unimport'
 export function generateBiomeLintConfigs(
   imports: Import[],
 ) {
-  const names =
-    imports
+  const names
+    = imports
       .map(i => i.as ?? i.name)
       .filter(Boolean)
       .sort()

--- a/src/core/biomelintrc.ts
+++ b/src/core/biomelintrc.ts
@@ -1,0 +1,16 @@
+import type { Import } from 'unimport'
+
+export function generateBiomeLintConfigs(
+  imports: Import[],
+) {
+  const names =
+    imports
+      .map(i => i.as ?? i.name)
+      .filter(Boolean)
+      .sort()
+
+  const config = { javascript: { globals: names } }
+  const jsonBody = JSON.stringify(config, null, 2)
+
+  return jsonBody
+}

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -12,7 +12,7 @@ import fg from 'fast-glob'
 import { vueTemplateAddon } from 'unimport/addons'
 import MagicString from 'magic-string'
 import { presets } from '../presets'
-import type { ESLintGlobalsPropValue, ESLintrc, BiomeLintrc, ImportExtended, Options } from '../types'
+import type { BiomeLintrc, ESLintGlobalsPropValue, ESLintrc, ImportExtended, Options } from '../types'
 import { generateESLintConfigs } from './eslintrc'
 import { generateBiomeLintConfigs } from './biomelintrc'
 import { resolversAddon } from './resolvers'
@@ -50,7 +50,7 @@ export function createContext(options: Options = {}, root = process.cwd()) {
   eslintrc.globalsPropValue = eslintrc.globalsPropValue === undefined ? true : eslintrc.globalsPropValue
 
   const biomelintrc: BiomeLintrc = options.biomelintrc || {}
-  biomelintrc.enabled = biomelintrc.enabled === undefined ? false : true
+  biomelintrc.enabled = biomelintrc.enabled !== undefined
   biomelintrc.filepath = biomelintrc.filepath || './.biomelintrc-auto-import.json'
 
   const resolvers = options.resolvers ? [options.resolvers].flat(2) : []
@@ -172,7 +172,6 @@ ${dts}`.trim()}\n`
     return config.globals as Record<string, ESLintGlobalsPropValue>
   }
 
-
   async function generateESLint() {
     return generateESLintConfigs(await unimport.getImports(), eslintrc, await parseESLint())
   }
@@ -223,7 +222,7 @@ ${dts}`.trim()}\n`
             lastBiomeLint = content
             return writeFile(biomelintrc.filepath!, content)
           }
-        })
+        }),
       )
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,6 @@ export type ImportsMap = Record<string, (string | ImportNameAlias)[]>
 
 export type ESLintGlobalsPropValue = boolean | 'readonly' | 'readable' | 'writable' | 'writeable'
 
-
 export interface ESLintrc {
   /**
    * @default false

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type ImportsMap = Record<string, (string | ImportNameAlias)[]>
 
 export type ESLintGlobalsPropValue = boolean | 'readonly' | 'readable' | 'writable' | 'writeable'
 
+
 export interface ESLintrc {
   /**
    * @default false
@@ -68,6 +69,19 @@ export interface ESLintrc {
    * @default true
    */
   globalsPropValue?: ESLintGlobalsPropValue
+}
+
+export interface BiomeLintrc {
+  /**
+   * @default false
+   */
+  enabled?: boolean
+  /**
+   * Filepath to save the generated eslint config
+   *
+   * @default './.eslintrc-auto-import.json'
+   */
+  filepath?: string
 }
 
 export interface Options {


### PR DESCRIPTION
Hi, Thank you for this plugin. awesome work.

I’ve added support for the BiomeJS linter.

The user can choose to enable either Eslintrc, Biomelintrc or both which is very handy.

and I’ve also updated the readme documentation accordingly.

```js
biomelintrc: {
    enabled: true, // Default `false`
    filepath: './.biomelintrc-auto-import.json', // Default `./.eslintrc-auto-import.json`
},
```