### PR TITLE
feat(astro): add `.astro` files to default include

### DIFF
--- a/examples/vite-astro/astro.config.mjs
+++ b/examples/vite-astro/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
         'svelte/store',
         'react',
       ],
+      dirs: ['src/utils/*.ts'],
       dts: './src/auto-imports.d.ts',
     }),
   ],

--- a/examples/vite-astro/src/components/Card.astro
+++ b/examples/vite-astro/src/components/Card.astro
@@ -6,6 +6,7 @@ export interface Props {
 }
 
 const { href, title, body } = Astro.props as Props;
+console.log(one)
 ---
 
 <li class="link-card">

--- a/examples/vite-astro/src/components/Card.svelte
+++ b/examples/vite-astro/src/components/Card.svelte
@@ -3,6 +3,7 @@
 
   onMount(() => {
     console.log('Test unplugin-auto-import ')
+    console.log(one)
   })
 
   function add() {

--- a/examples/vite-astro/src/components/Card.vue
+++ b/examples/vite-astro/src/components/Card.vue
@@ -1,17 +1,14 @@
 <script setup lang='ts'>
 const count = ref(0)
-let number = $ref(0)
 
 function add() {
   count.value++
-  number++
 }
 </script>
 
 <template>
   <div>
     <h1>Vue {{ count }}</h1>
-    <h1>Vue/maros {{ number }}</h1>
     <button @click="add">
       Add
     </button>

--- a/examples/vite-astro/src/utils/contants.ts
+++ b/examples/vite-astro/src/utils/contants.ts
@@ -1,0 +1,2 @@
+export const one = 1
+export const two = 1

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -102,7 +102,7 @@ ${dts}`.trim()}\n`
     })
 
   const filter = createFilter(
-    options.include || [/\.[jt]sx?$/, /\.vue$/, /\.vue\?vue/, /\.svelte$/],
+    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.svelte$/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
   )
   const dts = preferDTS === false

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,14 +153,14 @@ export interface Options {
   /**
    * Rules to include transforming target.
    *
-   * @default [/\.[jt]sx?$/, /\.vue\??/]
+   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.svelte$/]
    */
   include?: FilterPattern
 
   /**
    * Rules to exclude transforming target.
    *
-   * @default [/node_modules/, /\.git/]
+   * @default [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/]
    */
   exclude?: FilterPattern
 


### PR DESCRIPTION
### Description

Check title.

### Linked Issues

closes #352 


### Additional context

This PR also removes `vue/macros` in `vite-astro` example since `Vue 3.4` has removed it
