### PR TITLE
fixbug:resolve parse errors

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -163,7 +163,7 @@ ${dts}`.trim()}\n`
 
   async function parseESLint() {
     const configStr = existsSync(eslintrc.filepath!) ? await fs.readFile(eslintrc.filepath!, 'utf-8') : ''
-    const config = JSON.parse(configStr || '{ "globals": {} }')
+    const config = !eslintrc.filepath?.endsWith('json') ? JSON.parse(configStr.replace('export default', '').replace('module.exports =', '') || '{ "globals": {} }') : JSON.parse(configStr || '{ "globals": {} }')
     return config.globals as Record<string, ESLintGlobalsPropValue>
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When I used eslint9, I wanted to introduce an unplugin auto import eslint that ignored the file and changed the configuration file path to a file ending in. cjs or. mjs. The file was generated successfully, but the project reported an error and could not run. After debugging, it was found that the error was caused by using the JSON. parse method to parse these two formats of files
![1715735779884](https://github.com/unplugin/unplugin-auto-import/assets/33797397/843658a2-dee2-4905-84cf-ce08ef5d1e70)
![1715735810074](https://github.com/unplugin/unplugin-auto-import/assets/33797397/f19c938c-8273-4aef-9967-b38d75a9a1a9)
![1715735888115](https://github.com/unplugin/unplugin-auto-import/assets/33797397/97a06ee2-0e2b-4800-ac10-d57be402c861)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
