### PR TITLE
fix: skip `parseESlint` if eslint filepath is a js file

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -162,6 +162,8 @@ ${dts}`.trim()}\n`
   }
 
   async function parseESLint() {
+    if (eslintrc.filepath!.endsWith('js'))
+      return {} as Record<string, ESLintGlobalsPropValue>
     const configStr = existsSync(eslintrc.filepath!) ? await fs.readFile(eslintrc.filepath!, 'utf-8') : ''
     const config = JSON.parse(configStr || '{ "globals": {} }')
     return config.globals as Record<string, ESLintGlobalsPropValue>

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -161,12 +161,16 @@ ${dts}`.trim()}\n`
     return currentContent
   }
 
-  async function parseESLint() {
-    if (eslintrc.filepath!.endsWith('js'))
-      return {} as Record<string, ESLintGlobalsPropValue>
-    const configStr = existsSync(eslintrc.filepath!) ? await fs.readFile(eslintrc.filepath!, 'utf-8') : ''
+  async function parseESLint(): Promise<Record<string, ESLintGlobalsPropValue>> {
+    if (!eslintrc.filepath)
+      return {}
+    if (eslintrc.filepath.match(/\.[cm]?[jt]sx?$/)) // Skip JavaScript-like files
+      return {}
+    const configStr = existsSync(eslintrc.filepath!)
+      ? await fs.readFile(eslintrc.filepath!, 'utf-8')
+      : ''
     const config = JSON.parse(configStr || '{ "globals": {} }')
-    return config.globals as Record<string, ESLintGlobalsPropValue>
+    return config.globals
   }
 
   async function generateESLint() {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Focusing on the same bug in #498 . 

If `eslintrc.filepath` ends with "js", it will generate a javascript file (which is add in #494 ), however the `parseESlint` function still treat it as JSON file, which triggers an error.

In this PR, `parseESlint` returns `{}` if filepath ends with "js", instead of the `String.replace()` method used in #498 . Parsing is skipped in non-json mode.

If I understand correctly, skipping the parsing of previously generated eslint files would only have an impact on artifacts when the generated file was manually modified or the scope of automatic imports is narrowed. I'm not sure if resolve work fine, since I haven't use them.

### Linked Issues

null

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Maybe it will be better to be able to "import" it, but I cannot find an elegant way to do that.