### PR TITLE
docs: change install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export function Counter() {
 ## Install
 
 ```bash
-npm i -D unplugin-auto-import
+npm i unplugin-auto-import
 ```
 
 <details>


### PR DESCRIPTION
### Description

 `npm i -D` not safe with `npm ci`

### Additional context
keep same with https://github.com/unjs/unimport?tab=readme-ov-file#install
<!-- e.g. is there anything you'd like reviewers to focus on? -->
