### PR TITLE
fix: compatible with vue-loader experimentalInlineMatchResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ AutoImport({
   include: [
     /\.[tj]sx?$/, // .ts, .tsx, .js, .jsx
     /\.vue$/,
-    /\.vue\?vue/, // .vue
+    /\.vue(\.[t|j]sx?)?\?vue/, // .vue
     /\.md$/, // .md
   ],
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ AutoImport({
   include: [
     /\.[tj]sx?$/, // .ts, .tsx, .js, .jsx
     /\.vue$/,
-    /\.vue(\.[tj]sx?)?\?vue/, // .vue
+    /\.vue\?vue/, // .vue
+    /\.vue\.[tj]sx?\?vue/, // .vue (vue-loader with experimentalInlineMatchResource enabled)
     /\.md$/, // .md
   ],
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ AutoImport({
   include: [
     /\.[tj]sx?$/, // .ts, .tsx, .js, .jsx
     /\.vue$/,
-    /\.vue(\.[t|j]sx?)?\?vue/, // .vue
+    /\.vue(\.[tj]sx?)?\?vue/, // .vue
     /\.md$/, // .md
   ],
 

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -101,7 +101,7 @@ ${dts}`.trim()}\n`
     })
 
   const filter = createFilter(
-    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.svelte$/],
+    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.svelte$/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
   )
   const dts = preferDTS === false

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -101,7 +101,7 @@ ${dts}`.trim()}\n`
     })
 
   const filter = createFilter(
-    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.svelte$/],
+    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.vue\.[tj]sx?\?vue/, /\.svelte$/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
   )
   const dts = preferDTS === false

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -101,7 +101,7 @@ ${dts}`.trim()}\n`
     })
 
   const filter = createFilter(
-    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.svelte$/],
+    options.include || [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.svelte$/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
   )
   const dts = preferDTS === false

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,7 @@ export interface Options {
   /**
    * Rules to include transforming target.
    *
-   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.svelte$/]
+   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.vue\.[tj]sx?\?vue/, /\.svelte$/]
    */
   include?: FilterPattern
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,7 @@ export interface Options {
   /**
    * Rules to include transforming target.
    *
-   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue\?vue/, /\.svelte$/]
+   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.svelte$/]
    */
   include?: FilterPattern
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,7 @@ export interface Options {
   /**
    * Rules to include transforming target.
    *
-   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.svelte$/]
+   * @default [/\.[jt]sx?$/, /\.astro$/, /\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.svelte$/]
    */
   include?: FilterPattern
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When using vue-loader experimentalInlineMatchResource, the request will have an additional .js/.ts extension to match the js/ts module rule

```diff
// without experimentalInlineMatchResource
- src/App.vue?vue&type=script&setup=true&lang=ts
// with experimentalInlineMatchResource
+ src/App.vue.ts?vue&type=script&setup=true&lang=ts
```

But the default include RegExps failed to match the request

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
