### PR TITLE
feat(presets): add @lynx-js/react

### DIFF
--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,6 +1,7 @@
 import { builtinPresets } from 'unimport'
 import ahooks from './ahooks'
 import { jotai, jotaiUtils } from './jotai'
+import lynxReact from './lynx-react'
 import mobx from './mobx'
 import mobxReactLite from './mobx-react-lite'
 import preact from './preact'
@@ -39,6 +40,7 @@ export const presets = {
   '@vueuse/head': vueuseHead,
   'mobx': mobx,
   'mobx-react-lite': mobxReactLite,
+  '@lynx-js/react': lynxReact,
   'preact': preact,
   'quasar': quasar,
   'react': react,

--- a/src/presets/lynx-react.ts
+++ b/src/presets/lynx-react.ts
@@ -1,0 +1,23 @@
+import type { ImportsMap } from '../types'
+
+// https://lynxjs.org/api/react.html#functions
+export const CommonLynxReactAPI = [
+  'useState',
+  'useCallback',
+  'useMemo',
+  'useEffect',
+  'useRef',
+  'useContext',
+  'useReducer',
+  'useImperativeHandle',
+  'useDebugValue',
+  'useSyncExternalStore',
+  'lazy',
+  'memo',
+  'createRef',
+  'forwardRef',
+]
+
+export default <ImportsMap>{
+  '@lynx-js/react': CommonLynxReactAPI,
+}


### PR DESCRIPTION
### Description

This PR adds a new preset [`@lynx-js/react`](https://lynxjs.org/api/react/index.html) to the project, implementing the `CommonLynxReactAPI`. The preset focuses on providing React integration without relying on Lynx-specific APIs, ensuring broader compatibility and adherence to common React patterns. This allows users to leverage React functionality within the Lynx ecosystem using familiar conventions.

### Linked Issues

None

### Additional context

- The preset only include functions **both available** on [`reactjs`](https://fr.legacy.reactjs.org/) and [`@lynx-js/react`](https://lynxjs.org/api/react/index.html) (no `useTransition` for example).