### PR TITLE
fix: resolve path matching in hmr by using relative paths

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -1,4 +1,5 @@
 import type { Options } from '../types'
+import path from 'node:path'
 import { slash } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import pm from 'picomatch'
@@ -41,7 +42,8 @@ export default createUnplugin<Options>((options) => {
         }
       },
       async handleHotUpdate({ file }) {
-        if (ctx.dirs?.some(dir => pm.isMatch(slash(file), slash(typeof dir === 'string' ? dir : dir.glob))))
+        const relativeFile = path.relative(ctx.root, slash(file))
+        if (ctx.dirs?.some(dir => pm.isMatch(slash(relativeFile), slash(typeof dir === 'string' ? dir : dir.glob))))
           await ctx.scanDirs()
       },
       async configResolved(config) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes the Vite HMR path matching issue by converting absolute file paths to project-relative paths before comparing with glob patterns.

Before:

<img width="576" alt="image" src="https://github.com/user-attachments/assets/49ba211e-83ed-4e39-9e5d-0d1902cee8de" />

After: 

<img width="384" alt="SCR-20250325-ujqi" src="https://github.com/user-attachments/assets/6a37cf8c-b6c8-4860-93cf-4bbcb896fbd6" />

### Linked Issues

fix #551, fix #553