### PR TITLE
feat(presets): add taro.ts

### DIFF
--- a/src/presets/taro.ts
+++ b/src/presets/taro.ts
@@ -1,0 +1,25 @@
+import type { ImportsMap } from '../types'
+
+// @tarojs/taro/types/api/taro.hooks.d.ts
+export default <ImportsMap>{
+  '@tarojs/taro': [
+    'useRouter',
+    'useLoad',
+    'useReady',
+    'useDidShow',
+    'useDidHide',
+    'useUnload',
+    'usePullDownRefresh',
+    'useReachBottom',
+    'usePageScroll',
+    'useResize',
+    'useShareAppMessage',
+    'useTabItemTap',
+    'useShareTimeline',
+    'useAddToFavorites',
+    'useSaveExitState',
+    'useTitleClick',
+    'useOptionMenuClick',
+    'usePullIntercept',
+  ],
+}


### PR DESCRIPTION
### Description

This PR adds a new preset `@tarojs/taro` to the project, enabling taro to provide a custom Vue3 Composition API. The preset focus is to provide integration with Taro Vue3, allowing users to develop the Taro Vue3 Composition API faster

### Linked Issues

None

### Additional context
The preset only includes the content mentioned in the [taro.hooks.d.ts](https://github.com/NervJS/taro/blob/main/packages/taro/types/api/taro.hooks.d.ts) file in the `@tarojs/taro` package
