### PR TITLE
feat: use `ScanDirExportsOptions` from unimport

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ AutoImport({
 
   // Options for scanning directories for auto import
   dirsScanOptions: {
+    filePatterns: ['*.ts'], // Glob patterns for matching files
+    fileFilter: file => file.endsWith('.ts'), // Filter files
     types: true // Enable auto import the types under the directories
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { Arrayable, Awaitable } from '@antfu/utils'
-import type { AddonVueDirectivesOptions, Import, InlinePreset, PackagePreset, UnimportOptions } from 'unimport'
+import type { AddonVueDirectivesOptions, Import, InlinePreset, PackagePreset, ScanDirExportsOptions, UnimportOptions } from 'unimport'
 import type { FilterPattern } from 'unplugin-utils'
 import { PresetName } from './presets'
 
@@ -50,15 +50,6 @@ export type Resolver = ResolverFunction | ResolverResultObject
  * module, name, alias
  */
 export type ImportsMap = Record<string, (string | ImportNameAlias)[]>
-
-export interface ScanDirExportsOptions {
-  /**
-   * Register type exports
-   *
-   * @default true
-   */
-  types?: boolean
-}
 
 /**
  * Directory to search for import
@@ -140,7 +131,7 @@ export interface Options {
   /**
    * Options for scanning directories for auto import
    */
-  dirsScanOptions?: ScanDirExportsOptions
+  dirsScanOptions?: Omit<ScanDirExportsOptions, 'cwd'>
 
   /**
    * Path for directories to be auto imported

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -89,3 +89,103 @@ describe('import the types from the dirs', () => {
     expect(data).toContain('SpecialType')
   })
 })
+
+describe('dirsScanOptions', () => {
+  it('should filePatterns work', async () => {
+    const ctx = createContext({
+      dts: false,
+      dirsScanOptions: {
+        filePatterns: ['*.{ts,tsx}'],
+      },
+      dirs: [
+        'src/views',
+        'src/types',
+      ],
+    }, root)
+
+    await ctx.scanDirs()
+    const data = await ctx.generateDTS('')
+    expect(data).toContain('PageA')
+    expect(data).toContain('PageB')
+    expect(data).not.toContain('TypeA')
+    expect(data).not.toContain('TypeB')
+    expect(data).not.toContain('SpecialType')
+  })
+
+  it('should specific filePatterns work', async () => {
+    const ctx = createContext({
+      dts: false,
+      dirsScanOptions: {
+        types: true,
+        filePatterns: ['*.ts'],
+      },
+      dirs: ['src/views', 'src/types'],
+    }, root)
+
+    await ctx.scanDirs()
+    const data = await ctx.generateDTS('')
+    expect(data).not.toContain('PageA')
+    expect(data).not.toContain('PageB')
+    expect(data).toContain('TypeA')
+    expect(data).toContain('TypeB')
+    expect(data).toContain('SpecialType')
+  })
+
+  it('should fileFilter work', async () => {
+    const ctx = createContext({
+      dts: false,
+      dirsScanOptions: {
+        types: true,
+        fileFilter: (file: string) => file.includes('TypeA') || file.includes('PageA'),
+      },
+      dirs: ['src/views', 'src/types'],
+    }, root)
+
+    await ctx.scanDirs()
+    const data = await ctx.generateDTS('')
+    expect(data).toContain('TypeA')
+    expect(data).toContain('PageA')
+    expect(data).not.toContain('TypeB')
+    expect(data).not.toContain('PageB')
+    expect(data).not.toContain('SpecialType')
+  })
+
+  it('should fileFilter work when excluding all', async () => {
+    const ctx = createContext({
+      dts: false,
+      dirsScanOptions: {
+        types: true,
+        fileFilter: (_file: string) => false,
+      },
+      dirs: ['src/views', 'src/types'],
+    }, root)
+
+    await ctx.scanDirs()
+    const data = await ctx.generateDTS('')
+    expect(data).not.toContain('TypeA')
+    expect(data).not.toContain('PageA')
+    expect(data).not.toContain('TypeB')
+    expect(data).not.toContain('PageB')
+    expect(data).not.toContain('SpecialType')
+  })
+
+  it('should filePatterns and fileFilter work together', async () => {
+    const ctx = createContext({
+      dts: false,
+      dirsScanOptions: {
+        types: true,
+        filePatterns: ['*.{ts,tsx}'],
+        fileFilter: (file: string) => file.includes('PageA') || file.includes('SpecialType'),
+      },
+      dirs: ['src/views', 'src/types'],
+    }, root)
+
+    await ctx.scanDirs()
+    const data = await ctx.generateDTS('')
+    expect(data).toContain('PageA')
+    expect(data).toContain('SpecialType')
+    expect(data).not.toContain('PageB')
+    expect(data).not.toContain('TypeA')
+    expect(data).not.toContain('TypeB')
+  })
+})

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -35,7 +35,7 @@ describe('search', () => {
   })
 })
 
-describe('import the types from the dirs', () => {
+describe('dirsScanOptions', () => {
   it('should top level types enable work', async () => {
     const ctx = createContext({
       dts: false,
@@ -88,9 +88,7 @@ describe('import the types from the dirs', () => {
     expect(data).not.toContain('TypeB')
     expect(data).toContain('SpecialType')
   })
-})
 
-describe('dirsScanOptions', () => {
   it('should filePatterns work', async () => {
     const ctx = createContext({
       dts: false,

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -107,9 +107,9 @@ describe('dirsScanOptions', () => {
     const data = await ctx.generateDTS('')
     expect(data).toContain('PageA')
     expect(data).toContain('PageB')
-    expect(data).not.toContain('TypeA')
-    expect(data).not.toContain('TypeB')
-    expect(data).not.toContain('SpecialType')
+    expect(data).toContain('TypeA')
+    expect(data).toContain('TypeB')
+    expect(data).toContain('SpecialType')
   })
 
   it('should specific filePatterns work', async () => {
@@ -119,15 +119,18 @@ describe('dirsScanOptions', () => {
         types: true,
         filePatterns: ['*.ts'],
       },
-      dirs: ['src/views', 'src/types'],
+      dirs: [
+        'src/views',
+        'src/types',
+      ],
     }, root)
 
     await ctx.scanDirs()
     const data = await ctx.generateDTS('')
     expect(data).not.toContain('PageA')
     expect(data).not.toContain('PageB')
-    expect(data).toContain('TypeA')
-    expect(data).toContain('TypeB')
+    expect(data).not.toContain('TypeA')
+    expect(data).not.toContain('TypeB')
     expect(data).toContain('SpecialType')
   })
 
@@ -138,7 +141,10 @@ describe('dirsScanOptions', () => {
         types: true,
         fileFilter: (file: string) => file.includes('TypeA') || file.includes('PageA'),
       },
-      dirs: ['src/views', 'src/types'],
+      dirs: [
+        'src/views',
+        'src/types',
+      ],
     }, root)
 
     await ctx.scanDirs()
@@ -157,7 +163,10 @@ describe('dirsScanOptions', () => {
         types: true,
         fileFilter: (_file: string) => false,
       },
-      dirs: ['src/views', 'src/types'],
+      dirs: [
+        'src/views',
+        'src/types',
+      ],
     }, root)
 
     await ctx.scanDirs()
@@ -175,17 +184,20 @@ describe('dirsScanOptions', () => {
       dirsScanOptions: {
         types: true,
         filePatterns: ['*.{ts,tsx}'],
-        fileFilter: (file: string) => file.includes('PageA') || file.includes('SpecialType'),
+        fileFilter: (file: string) => file.includes('PageA'),
       },
-      dirs: ['src/views', 'src/types'],
+      dirs: [
+        'src/views',
+        'src/types',
+      ],
     }, root)
 
     await ctx.scanDirs()
     const data = await ctx.generateDTS('')
     expect(data).toContain('PageA')
-    expect(data).toContain('SpecialType')
+    expect(data).toContain('TypeA')
+    expect(data).not.toContain('SpecialType')
     expect(data).not.toContain('PageB')
-    expect(data).not.toContain('TypeA')
     expect(data).not.toContain('TypeB')
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR uses `ScanDirExportsOptions` from `unimport`, and removes the local definition.
