### PR TITLE
fix: dirs hot reload without wildcards

### DIFF
--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -6,7 +6,7 @@ import process from 'node:process'
 import { isString, slash, throttle, toArray } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import MagicString from 'magic-string'
-import { createUnimport, resolvePreset } from 'unimport'
+import { createUnimport, normalizeScanDirs, resolvePreset } from 'unimport'
 import { createFilter } from 'unplugin-utils'
 import { presets } from '../presets'
 import { generateBiomeLintConfigs } from './biomelintrc'
@@ -285,6 +285,13 @@ ${dts}`.trim()}\n`
     .filter(isString)
     .map(path => resolve(root, path))
 
+  const normalizedDirPaths = dirs?.length
+    ? dirs.flatMap(dir => normalizeScanDirs([dir], {
+        ...dirsScanOptions,
+        cwd: root,
+      }))
+    : []
+
   return {
     root,
     dirs,
@@ -297,6 +304,7 @@ ${dts}`.trim()}\n`
     generateESLint,
     unimport,
     configFilePaths,
+    normalizedDirPaths,
   }
 }
 

--- a/src/core/ctx.ts
+++ b/src/core/ctx.ts
@@ -3,7 +3,7 @@ import type { BiomeLintrc, ESLintrc, ImportExtended, Options } from '../types'
 import { existsSync, promises as fs } from 'node:fs'
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import process from 'node:process'
-import { slash, throttle, toArray } from '@antfu/utils'
+import { isString, slash, throttle, toArray } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import MagicString from 'magic-string'
 import { createUnimport, resolvePreset } from 'unimport'
@@ -276,6 +276,15 @@ ${dts}`.trim()}\n`
     }
   }
 
+  const configFilePaths = [
+    dts,
+    eslintrc.filepath,
+    biomelintrc.filepath,
+    dumpUnimportItems,
+  ]
+    .filter(isString)
+    .map(path => resolve(root, path))
+
   return {
     root,
     dirs,
@@ -287,6 +296,7 @@ ${dts}`.trim()}\n`
     generateDTS,
     generateESLint,
     unimport,
+    configFilePaths,
   }
 }
 

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -3,7 +3,6 @@ import type { Options } from '../types'
 import { slash } from '@antfu/utils'
 import { isPackageExists } from 'local-pkg'
 import pm from 'picomatch'
-import { normalizeScanDirs } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { createContext, EXCLUDE_RE_LIST, INCLUDE_RE_LIST } from './ctx'
 
@@ -59,13 +58,9 @@ export default createUnplugin<Options>((options) => {
 
         const normalizedFilePath = slash(file)
 
-        const shouldRescan = ctx.dirs.some((dir) => {
-          const normalizedDirPaths = normalizeScanDirs([dir], {
-            ...options.dirsScanOptions,
-            cwd: ctx.root,
-          })
-          return normalizedDirPaths.some(dirPath => pm.isMatch(normalizedFilePath, dirPath.glob))
-        })
+        const shouldRescan = ctx.normalizedDirPaths.some(dirPath =>
+          pm.isMatch(normalizedFilePath, dirPath.glob),
+        )
 
         if (shouldRescan)
           await ctx.scanDirs()

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -54,6 +54,9 @@ export default createUnplugin<Options>((options) => {
         if (!ctx.dirs?.length)
           return
 
+        if (ctx.configFilePaths.includes(file))
+          return
+
         const normalizedFilePath = slash(file)
 
         const shouldRescan = ctx.dirs.some((dir) => {


### PR DESCRIPTION
### Description

This PR fixes hot reload functionality when `dirs` is configured without wildcards.

Previously, hot reload only worked for patterns like `./composables/*` or `./composables/**` but failed for `./composables`:

```js
// ✅ Works (with wildcards)
dirs: ['./composables/*', './composables/**']

// ❌ Broken (without wildcards) 
dirs: ['./composables']
```

The issue was that `picomatch` couldn't properly match files against directory paths without glob patterns.

The fix normalizes directory paths using `unimport's normalizeScanDirs` to properly handle both wildcard and non-wildcard patterns, ensuring files are correctly matched regardless of configuration style.

As an additional optimization, it now skips hot reload checks for auto-generated config files to prevent unnecessary re-scans.

### Linked Issues

resolved #583
